### PR TITLE
Changed Download Bar

### DIFF
--- a/resource/layout/uistatuspanel.layout
+++ b/resource/layout/uistatuspanel.layout
@@ -28,10 +28,10 @@
 	
 	layout
 	{
-		region { name="ProgressRegion" y=18 width=max height=28 align=top margin=0 margin-bottom=1 }
-	 	region { name="statusRegion" width=max height=44 align=bottom margin=6 margin-bottom=8 } 
-		
-		place { control=StatusProgressbar region="ProgressRegion" width=320 height=2 margin-top=4 align="top-center" }
-		place { control="StatusDownloading, StatusPaused, StatusComplete"  align="right" spacing=3 margin-top=15 margin-right=10 }
+		region { name="ProgressRegion" width=max height=7 align=bottom }
+		region { name="statusRegion" width=max height=42 align=bottom margin-right=6 margin-left=6 margin-top=-1  } 
+	
+		place { control=StatusProgressbar region="ProgressRegion" width=max height=1 margin-left=10 margin-right=10 margin-top=3 align="top-center" }
+		place { control="StatusDownloading, StatusPaused, StatusComplete" region="statusRegion"  align="top-center" margin-top=15 }
 	}
 }


### PR DESCRIPTION

![new_download_bar](https://cloud.githubusercontent.com/assets/3616220/6906487/1c1085ac-d6e4-11e4-9fbb-bbf933dbd506.PNG)
Re-centered the downloads text, and moved the download progress bar down, while decreasing its height